### PR TITLE
Allow greater versions of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Mezcalito file upload plugin for Sylius.",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "sylius/sylius": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
Was forced to 7 due to the semver specified, changed to allow >= 7.2